### PR TITLE
keep update with latest apispec

### DIFF
--- a/flask_restplus_patched/model.py
+++ b/flask_restplus_patched/model.py
@@ -1,6 +1,10 @@
 try:
-    from apispec.ext.marshmallow.openapi import OpenAPIConverter
-    openapi = OpenAPIConverter(openapi_version='2.0')
+    try:
+        from apispec.ext.marshmallow import OpenAPIConverter, resolver
+        openapi = OpenAPIConverter('3.0.2', resolver, None)
+    except ImportError:
+        from apispec.ext.marshmallow.openapi import OpenAPIConverter
+        openapi = OpenAPIConverter('3.0.2')
     fields2jsonschema = openapi.fields2jsonschema
     field2property = openapi.field2property
 except ImportError:

--- a/flask_restplus_patched/swagger.py
+++ b/flask_restplus_patched/swagger.py
@@ -1,6 +1,10 @@
 try:
-    from apispec.ext.marshmallow.openapi import OpenAPIConverter
-    openapi = OpenAPIConverter(openapi_version='2.0')
+    try:
+        from apispec.ext.marshmallow import OpenAPIConverter, resolver
+        openapi = OpenAPIConverter('3.0.2', resolver, None)
+    except ImportError:
+        from apispec.ext.marshmallow.openapi import OpenAPIConverter
+        openapi = OpenAPIConverter('3.0.2')
     schema2parameters = openapi.schema2parameters
 except ImportError:
     from apispec.ext.marshmallow.swagger import schema2parameters


### PR DESCRIPTION
Since the latest apiapec has release version 1.1.1 which is not compatible with the current flask-restplus-patched, I did a simple patch for it.
I set the openversion to '3.0.2', because the version '2.0' is not work on my current project.I don't know if you care it, how about setting the version from app.config of flask?